### PR TITLE
Update to use latest OneTrust SDK

### DIFF
--- a/mParticle-OneTrust.podspec
+++ b/mParticle-OneTrust.podspec
@@ -14,7 +14,7 @@ Pod::Spec.new do |s|
     s.social_media_url = "https://twitter.com/mparticle"
 
     
-    s.ios.deployment_target = "9.0"
+    s.ios.deployment_target = "11.0"
     s.ios.source_files      = 'mParticle-OneTrust/*.{h,m}'
     s.ios.dependency 'mParticle-Apple-SDK/mParticle', '~> 8.0'
     s.ios.dependency 'OneTrust-CMP-XCFramework', '~> 6.17'

--- a/mParticle-OneTrust.podspec
+++ b/mParticle-OneTrust.podspec
@@ -17,5 +17,6 @@ Pod::Spec.new do |s|
     s.ios.deployment_target = "9.0"
     s.ios.source_files      = 'mParticle-OneTrust/*.{h,m}'
     s.ios.dependency 'mParticle-Apple-SDK/mParticle', '~> 8.0'
+    s.ios.dependency 'OneTrust-CMP-XCFramework', '~> 6.17'
 
 end

--- a/mParticle-OneTrust/MPKitOneTrust.h
+++ b/mParticle-OneTrust/MPKitOneTrust.h
@@ -10,5 +10,6 @@
 @property (nonatomic, strong, nonnull) NSDictionary *configuration;
 @property (nonatomic, strong, nullable) NSDictionary *launchOptions;
 @property (nonatomic, unsafe_unretained, readonly) BOOL started;
+@property (nonatomic, strong, nullable) NSDictionary *consentMapping;
 
 @end

--- a/mParticle-OneTrust/MPKitOneTrust.m
+++ b/mParticle-OneTrust/MPKitOneTrust.m
@@ -1,4 +1,5 @@
 #import "MPKitOneTrust.h"
+#import <OTPublishersHeadlessSDK/OTPublishersHeadlessSDK-Swift.h>
 
 @implementation MPKitOneTrust
 
@@ -45,6 +46,23 @@
         
         self->_started = YES;
         
+        // READ consent data mapping
+        NSString *mpConsentMapping = [[NSUserDefaults standardUserDefaults] stringForKey:@"OT_mP_Mapping"];
+
+        self->_consentMapping = [self parseConsentMapping:mpConsentMapping];
+
+
+        for(NSString *consentKey in [self.consentMapping allKeys]) {
+            // Add consent change observer for all known OneTrust Events
+            [NSNotificationCenter.defaultCenter addObserver:self selector:@selector(actionConsent:) name:consentKey object:NULL];
+
+            // Fetch consent keys from one trust and pre-populate
+            NSNumber *status = [[NSNumber alloc] initWithUnsignedChar:[OTPublishersHeadlessSDK.shared getConsentStatusForCategory:consentKey]];
+
+            // Generate consents states for known events
+            [self createConsentEvent:consentKey :status];
+        }
+
         dispatch_async(dispatch_get_main_queue(), ^{
             NSDictionary *userInfo = @{mParticleKitInstanceKey:[[self class] kitCode]};
             
@@ -53,6 +71,64 @@
                                                               userInfo:userInfo];
         });
     });
+}
+
+// Listener for Consent Change dispatched by One Trust
+-(void)actionConsent:(NSNotification*)notification {
+    NSString *category = notification.name; // Cookie Name
+    NSNumber *status = notification.object; // BOOL-ish value for consent
+    category = notification.name;
+
+    // Fire consent change event
+    [self createConsentEvent:category :status];
+}
+
+// Parses the raw consent mapping from the mParticle UI into simple map
+- (NSDictionary*)parseConsentMapping:(NSString*)rawConsentMapping {
+    NSData *jsonData = [rawConsentMapping dataUsingEncoding:NSUTF8StringEncoding];
+    NSError *error;
+
+    NSMutableDictionary *consentMapping = [[NSMutableDictionary alloc] init];
+
+    id jsonObject = [NSJSONSerialization JSONObjectWithData:jsonData options:0 error:&error];
+
+        if (error) {
+            NSLog(@"Error parsing JSON: %@", error);
+        }
+        else
+        {
+            if ([jsonObject isKindOfClass:[NSArray class]])
+            {
+                for (NSDictionary *element in jsonObject) {
+                    consentMapping[element[@"value"]] = element[@"map"];
+                }
+            }
+            // TODO: Should we throw an error if the consent mapping
+            //       is not an array?
+            // else {
+            //     NSDictionary *jsonDictionary = (NSDictionary *)jsonObject;
+            //     NSLog(@"jsonDictionary - %@",jsonDictionary);
+            // }
+        }
+    return consentMapping;
+}
+
+// Creates an mParticle Consent Event
+-(void)createConsentEvent:(NSString*)cookieName
+                         :(NSNumber*)status {
+    // TODO: Can we move this out of the function?
+    MParticleUser *user = [MParticle sharedInstance].identity.currentUser;
+
+    MPConsentState *consentState = [[MPConsentState alloc] init];
+    MPGDPRConsent *gdprConsent = [[MPGDPRConsent alloc] init];
+
+    NSString *purpose = self->_consentMapping[cookieName];
+
+    gdprConsent.consented = status.intValue == 1;
+    gdprConsent.timestamp = [[NSDate alloc] init];
+
+    [consentState addGDPRConsentState:gdprConsent purpose:purpose];
+    user.consentState = consentState;
 }
 
 - (id const)providerKitInstance {

--- a/mParticle-OneTrust/MPKitOneTrust.m
+++ b/mParticle-OneTrust/MPKitOneTrust.m
@@ -99,7 +99,11 @@
             if ([jsonObject isKindOfClass:[NSArray class]])
             {
                 for (NSDictionary *element in jsonObject) {
-                    consentMapping[element[@"value"]] = element[@"map"];
+                    if (element[@"value"] != nil && element[@"map"] != nil) {
+                        consentMapping[element[@"value"]] = element[@"map"];
+                    } else {
+                        NSLog(@"Warning: Invalid consent mapping - %@", element);
+                    }
                 }
             } else {
                 NSLog(@"Warning: One Trust Integration initialized with invalid Consent Mapping.\n jsonDictionary - %@", jsonObject);

--- a/mParticle-OneTrust/MPKitOneTrust.m
+++ b/mParticle-OneTrust/MPKitOneTrust.m
@@ -77,7 +77,6 @@
 -(void)actionConsent:(NSNotification*)notification {
     NSString *category = notification.name; // Cookie Name
     NSNumber *status = notification.object; // BOOL-ish value for consent
-    category = notification.name;
 
     // Fire consent change event
     [self createConsentEvent:category :status];
@@ -102,13 +101,9 @@
                 for (NSDictionary *element in jsonObject) {
                     consentMapping[element[@"value"]] = element[@"map"];
                 }
+            } else {
+                NSLog(@"Warning: One Trust Integration initialized with invalid Consent Mapping.\n jsonDictionary - %@", jsonObject);
             }
-            // TODO: Should we throw an error if the consent mapping
-            //       is not an array?
-            // else {
-            //     NSDictionary *jsonDictionary = (NSDictionary *)jsonObject;
-            //     NSLog(@"jsonDictionary - %@",jsonDictionary);
-            // }
         }
     return consentMapping;
 }
@@ -116,7 +111,6 @@
 // Creates an mParticle Consent Event
 -(void)createConsentEvent:(NSString*)cookieName
                          :(NSNumber*)status {
-    // TODO: Can we move this out of the function?
     MParticleUser *user = [MParticle sharedInstance].identity.currentUser;
 
     MPConsentState *consentState = [[MPConsentState alloc] init];


### PR DESCRIPTION
One Trust recently updated their SDK to provide callbacks and updated methods for fetching consent state. We needed to update this kit accordingly.