### PR TITLE
feat: Add Vendor Level Consent to OneTrust Kit

### DIFF
--- a/mParticle-OneTrust/MPKitOneTrust.h
+++ b/mParticle-OneTrust/MPKitOneTrust.h
@@ -11,5 +11,6 @@
 @property (nonatomic, strong, nullable) NSDictionary *launchOptions;
 @property (nonatomic, unsafe_unretained, readonly) BOOL started;
 @property (nonatomic, strong, nullable) NSDictionary *consentMapping;
+@property (nonatomic, strong, nullable) NSDictionary *venderConsentMapping;
 
 @end

--- a/mParticle-OneTrust/MPKitOneTrust.m
+++ b/mParticle-OneTrust/MPKitOneTrust.m
@@ -58,7 +58,7 @@
 
         for(NSString *consentKey in [self.consentMapping allKeys]) {
             // Add consent change observer for all known OneTrust Events
-            [NSNotificationCenter.defaultCenter addObserver:self selector:@selector(actionConsent:) name:consentKey object:NULL];
+            [NSNotificationCenter.defaultCenter addObserver:self selector:@selector(actionConsent:) name:consentKey object:nil];
 
             // Fetch consent keys from one trust and pre-populate
             NSNumber *status = [[NSNumber alloc] initWithUnsignedChar:[OTPublishersHeadlessSDK.shared getConsentStatusForCategory:consentKey]];
@@ -69,7 +69,7 @@
         
         for(NSString *consentKey in [self.venderConsentMapping allKeys]) {
             // Add consent change observer for all known OneTrust Vendor Events
-            [NSNotificationCenter.defaultCenter addObserver:self selector:@selector(actionConsent:) name:consentKey object:NULL];
+            [NSNotificationCenter.defaultCenter addObserver:self selector:@selector(actionConsent:) name:consentKey object:nil];
 
             // Fetch consent keys from one trust and pre-populate
             NSNumber *status = [[NSNumber alloc] initWithUnsignedChar:[OTPublishersHeadlessSDK.shared getConsentStatusForSDKId:consentKey]];


### PR DESCRIPTION
# Summary

Read the vendor consent data mapping under the key 'vendorConsentGroups'

Add an observer that updates consent state for any change on each SDK ID

Fetch consent status from oneTrust and set the corresponding consent state in MP