### PR TITLE
fix: Update all Consent States on OneTrust Dismissal Notification

### DIFF
--- a/mParticle-OneTrust.podspec
+++ b/mParticle-OneTrust.podspec
@@ -17,6 +17,6 @@ Pod::Spec.new do |s|
     s.ios.deployment_target = "11.0"
     s.ios.source_files      = 'mParticle-OneTrust/*.{h,m}'
     s.ios.dependency 'mParticle-Apple-SDK/mParticle', '~> 8.0'
-    s.ios.dependency 'OneTrust-CMP-XCFramework', '~> 6.17'
+    s.ios.dependency 'OneTrust-CMP-XCFramework', '~> 202302.1.0'
 
 end

--- a/mParticle-OneTrust/MPKitOneTrust.m
+++ b/mParticle-OneTrust/MPKitOneTrust.m
@@ -133,7 +133,7 @@
                          :(NSNumber*)status {
     MParticleUser *user = [MParticle sharedInstance].identity.currentUser;
 
-    MPConsentState *consentState = [[MPConsentState alloc] init];
+    MPConsentState *consentState = user.consentState;
 
     NSString *purpose = consentMapping[cookieName][@"purpose"];
     NSString *regulation = consentMapping[cookieName][@"regulation"];


### PR DESCRIPTION
## Summary
 - Instead of creating and listening to a notification on every purpose we will now update all consent states any time the OneTrust UI (banner or preference center) is dismissed.

 ## Testing Plan
 - Tested in sample app provided by TSE and confirmed fix with TSE on their machine

 ## Reference Issue (For mParticle employees only.  Ignore if you are an outside contributor)
 - Closes https://go.mparticle.com/work/SQDSDKS-5212
