### PR TITLE
chore: Update OneTrust SDK to v202308.2.0

### DIFF
--- a/mParticle-OneTrust.podspec
+++ b/mParticle-OneTrust.podspec
@@ -18,6 +18,6 @@ Pod::Spec.new do |s|
     s.ios.source_files      = 'mParticle-OneTrust/*.{h,m}'
     s.ios.dependency 'mParticle-Apple-SDK/mParticle', '~> 8.0'
     #OneTrust changed their version formating making automatic support up to the next major version no longer possible
-    s.ios.dependency 'OneTrust-CMP-XCFramework', '~> 202302.1.0'
+    s.ios.dependency 'OneTrust-CMP-XCFramework', '~> 202308.2.0'
 
 end


### PR DESCRIPTION
 ## Summary
 - Update OneTrust SDK to [v202308.2.0](https://github.com/Zentrust/OTPublishersHeadlessSDK/releases/tag/202308.2.0).

 ## Testing Plan
 - [ ] Was this tested locally? If not, explain why.
Testing is WIP

 ## Reference Issue (For mParticle employees only.  Ignore if you are an outside contributor)
 - [Zendesk Ticket](https://mparticlehelp.zendesk.com/agent/tickets/12925)
 - [Jira Ticket](https://mparticle-eng.atlassian.net/browse/SQDSDKS-5659)