### PR TITLE
feat: Update to October 2023 Version

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -16,7 +16,7 @@ let package = Package(
                .upToNextMajor(from: "8.0.0")),
       .package(name: "OTPublishersHeadlessSDK",
                url: "https://github.com/Zentrust/OTPublishersHeadlessSDK",
-               .upToNextMajor(from: "202303.1.0")),
+               .upToNextMajor(from: "202310.1.3")),
     ],
     targets: [
         .target(

--- a/mParticle-OneTrust.podspec
+++ b/mParticle-OneTrust.podspec
@@ -18,6 +18,6 @@ Pod::Spec.new do |s|
     s.ios.source_files      = 'mParticle-OneTrust/*.{h,m}'
     s.ios.dependency 'mParticle-Apple-SDK/mParticle', '~> 8.0'
     #OneTrust changed their version formating making automatic support up to the next major version no longer possible
-    s.ios.dependency 'OneTrust-CMP-XCFramework', '~> 202302.1.0'
+    s.ios.dependency 'OneTrust-CMP-XCFramework', '~> 202310.1.3'
 
 end


### PR DESCRIPTION
## Summary
 - Update to the October release of OneTrust

 ## Testing Plan
 - Confirmed basic OneTrust functionality in their UI/sample app

 ## Reference Issue (For mParticle employees only.  Ignore if you are an outside contributor)
 - Closes https://go.mparticle.com/work/SQDSDKS-5718
