### PR TITLE
fix: Update to Support Unique OneTrust Versioning

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -14,14 +14,11 @@ let package = Package(
       .package(name: "mParticle-Apple-SDK",
                url: "https://github.com/mParticle/mparticle-apple-sdk",
                .upToNextMajor(from: "8.0.0")),
-      .package(name: "OTPublishersHeadlessSDK",
-               url: "https://github.com/Zentrust/OTPublishersHeadlessSDK",
-               .upToNextMajor(from: "202310.1.3")),
     ],
     targets: [
         .target(
             name: "mParticle-OneTrust",
-            dependencies: ["mParticle-Apple-SDK", "OTPublishersHeadlessSDK"],
+            dependencies: ["mParticle-Apple-SDK"],
             path: "mParticle-OneTrust",
             exclude: ["Info.plist"],
             publicHeadersPath: "."

--- a/README.md
+++ b/README.md
@@ -18,7 +18,9 @@ This repository contains the [OneTrust](https://www.onetrust.com/) integration f
 
    _Note: OneTrust does not support Carthage at this moment_
 
-2. Verify that you are using the correct version of your OneTrust SDK as specified in _Cookie Complience > Integrations > SDKs_ on app.onetrust.com.
+2. Add the OneTrust SDK following their [documentation](https://developer.onetrust.com/onetrust/docs/add-sdk-to-app-ios-tvos) and ensure you pin to the correct version of the OneTrust SDK as you specified in the OneTrust UI on app.onetrust.com.
+
+   _Note: OneTrust is unique in their versioning and in that you must specify your version used from a constrained list in their UI. This necessitates that we cannot pin the version of the OneTrust SDK in this kit. Therefore you must pin the correct version in the podspec or package.swift of your application_
 
 3. Follow the mParticle iOS SDK [quick-start](https://github.com/mParticle/mparticle-apple-sdk), then rebuild and launch your app, and verify that you see `"Included kits: { OneTrust }"` in your Xcode console
 

--- a/mParticle-OneTrust.podspec
+++ b/mParticle-OneTrust.podspec
@@ -10,14 +10,14 @@ Pod::Spec.new do |s|
     s.homepage         = "https://www.mparticle.com"
     s.license          = { :type => 'Apache 2.0', :file => 'LICENSE' }
     s.author           = { "mParticle" => "support@mparticle.com" }
-    s.source           = { :git => "https://github.com/mparticle-integrations/mparticle-apple-integration-onetrust.git", :tag => s.version.to_s }
+    s.source           = { :git => "https://github.com/mparticle-integrations/mparticle-apple-integration-onetrust.git", :tag => "v" + s.version.to_s }
     s.social_media_url = "https://twitter.com/mparticle"
 
     
     s.ios.deployment_target = "11.0"
     s.ios.source_files      = 'mParticle-OneTrust/*.{h,m}'
     s.ios.dependency 'mParticle-Apple-SDK/mParticle', '~> 8.0'
-    #OneTrust changed their version formating making automatic support up to the next major version no longer possible
-    s.ios.dependency 'OneTrust-CMP-XCFramework', '~> 202310.1.3'
+    #OneTrust's unique version formating makes automatic support up to the next major version no longer possible. Additionally, as a specific version is required in their UI for their SDK to function we do not include a specific version of the 'OneTrust-CMP-XCFramework' here and expect the version to be defined in the client app.
+    s.ios.dependency 'OneTrust-CMP-XCFramework'
 
 end


### PR DESCRIPTION
## Summary
 - With OneTrust's unique versioning and requirements to set SDK from a constrained list in their UI the best solution seemed to be to unpin from any specific OneTrust version and update the README to warn users that the must set this themselves.

 ## Testing Plan
 - Tested using December release of OneTrust. Though this change doesn't change any functionality.

 ## Reference Issue (For mParticle employees only.  Ignore if you are an outside contributor)
 - Closes https://go.mparticle.com/work/SQDSDKS-5970
